### PR TITLE
購入履歴及び購入明細画面用テーブルの作成

### DIFF
--- a/lamp_dock/append_schema.sql
+++ b/lamp_dock/append_schema.sql
@@ -1,0 +1,192 @@
+-- phpMyAdmin SQL Dump
+-- version 5.0.2
+-- https://www.phpmyadmin.net/
+--
+-- ホスト: mysql
+-- 生成日時: 2020 年 4 月 28 日 12:58
+-- サーバのバージョン： 5.7.29
+-- PHP のバージョン: 7.4.4
+
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+START TRANSACTION;
+SET time_zone = "+00:00";
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+
+--
+-- データベース: `sample`
+--
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `carts`
+--
+
+CREATE TABLE `carts` (
+  `cart_id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  `item_id` int(11) NOT NULL,
+  `amount` int(11) NOT NULL,
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- テーブルのデータのダンプ `carts`
+--
+
+INSERT INTO `carts` (`cart_id`, `user_id`, `item_id`, `amount`, `created`, `updated`) VALUES
+(4, 4, 32, 2, '2020-04-25 20:18:10', '2020-04-25 20:18:14');
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `items`
+--
+
+CREATE TABLE `items` (
+  `item_id` int(11) NOT NULL,
+  `name` varchar(100) NOT NULL,
+  `stock` int(11) NOT NULL,
+  `price` int(11) NOT NULL,
+  `image` varchar(100) NOT NULL,
+  `status` int(11) NOT NULL,
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- テーブルのデータのダンプ `items`
+--
+
+INSERT INTO `items` (`item_id`, `name`, `stock`, `price`, `image`, `status`, `created`, `updated`) VALUES
+(32, 'hacked', 1, 18000, 'ny1owjn3yqs0cow8w4ws.jpg', 1, '2019-08-09 09:12:30', '2020-04-25 18:26:01'),
+(33, 'ハリネズミ', 17, 50000, '16scmunsexdwcosw88g0.jpg', 1, '2019-08-09 09:13:33', '2020-04-25 18:18:00'),
+(35, '<h1>ねこ</h1>', 9, 200, '48fg9rj6g5ogo8wok8w8.jpg', 1, '2020-04-15 22:42:08', '2020-04-18 12:14:45');
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `order_historys`
+--
+
+CREATE TABLE `order_historys` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  `order_datetime` datetime NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `order_item_historys`
+--
+
+CREATE TABLE `order_item_historys` (
+  `order_id` int(11) NOT NULL,
+  `item_id` int(11) NOT NULL,
+  `order_price` int(11) NOT NULL,
+  `amount` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- --------------------------------------------------------
+
+--
+-- テーブルの構造 `users`
+--
+
+CREATE TABLE `users` (
+  `user_id` int(11) NOT NULL,
+  `name` varchar(20) NOT NULL,
+  `password` varchar(20) NOT NULL,
+  `type` int(11) NOT NULL DEFAULT '2',
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- テーブルのデータのダンプ `users`
+--
+
+INSERT INTO `users` (`user_id`, `name`, `password`, `type`, `created`, `updated`) VALUES
+(1, 'sampleuser', 'password', 2, '2019-08-07 01:17:12', '2019-08-07 01:17:12'),
+(4, 'admin', 'admin', 1, '2019-08-07 10:45:11', '2019-08-07 10:45:11');
+
+--
+-- ダンプしたテーブルのインデックス
+--
+
+--
+-- テーブルのインデックス `carts`
+--
+ALTER TABLE `carts`
+  ADD PRIMARY KEY (`cart_id`),
+  ADD KEY `item_id` (`item_id`),
+  ADD KEY `user_id` (`user_id`);
+
+--
+-- テーブルのインデックス `items`
+--
+ALTER TABLE `items`
+  ADD PRIMARY KEY (`item_id`);
+
+--
+-- テーブルのインデックス `order_historys`
+--
+ALTER TABLE `order_historys`
+  ADD PRIMARY KEY (`id`);
+
+--
+-- テーブルのインデックス `users`
+--
+ALTER TABLE `users`
+  ADD PRIMARY KEY (`user_id`);
+
+--
+-- ダンプしたテーブルのAUTO_INCREMENT
+--
+
+--
+-- テーブルのAUTO_INCREMENT `carts`
+--
+ALTER TABLE `carts`
+  MODIFY `cart_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
+
+--
+-- テーブルのAUTO_INCREMENT `items`
+--
+ALTER TABLE `items`
+  MODIFY `item_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=36;
+
+--
+-- テーブルのAUTO_INCREMENT `order_historys`
+--
+ALTER TABLE `order_historys`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- テーブルのAUTO_INCREMENT `users`
+--
+ALTER TABLE `users`
+  MODIFY `user_id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
+
+--
+-- ダンプしたテーブルの制約
+--
+
+--
+-- テーブルの制約 `carts`
+--
+ALTER TABLE `carts`
+  ADD CONSTRAINT `carts_ibfk_1` FOREIGN KEY (`item_id`) REFERENCES `items` (`item_id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `carts_ibfk_2` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`);
+COMMIT;
+
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;


### PR DESCRIPTION
２つテーブルを追加しました
order_historys
・注文番号（オートインクリメント）
・購入者番号
・購入日時

order_item_historys
・注文番号
・商品番号
・購入時単価
・購入数

※注文毎の合計金額は注文番号でグループを作り
商品購入時の単価と購入数を掛けたものを各々足せば出るので
テーブルには入れていません。
