### PR TITLE
追加テーブルへのデータ保存をクラスを用いて実行

### DIFF
--- a/www/html/finish.php
+++ b/www/html/finish.php
@@ -18,19 +18,11 @@ $carts = get_user_carts($db, $user['user_id']);
 try{
   $db->beginTransaction();
 
+  //購入時に在庫数を一つ減らしカートから削除する処理
   purchase_carts($db, $carts);
   $user_id = $user['user_id'];
   $purchase_data = new Order($db, $user_id);
-  $purchase_data->insert_order_historys();
-  $order_id = $db->lastInsertId('id');
-
-//オーダーIDを取得
-  foreach($carts as $cart){
-    $item_id = $cart['item_id'];
-    $order_price = $cart['price'];
-    $amount = $cart['amount'];
-    $purchase_data->insert_order_item_historys($order_id,$item_id,$order_price,$amount);
-  }
+  $purchase_data->insert_order_historys($carts);
   $db->commit();
 }catch(PDOException $e){
   $db->rollBack();

--- a/www/html/finish.php
+++ b/www/html/finish.php
@@ -13,14 +13,32 @@ if(is_logined() === false){
 
 $db = get_db_connect();
 $user = get_login_user($db);
-
 $carts = get_user_carts($db, $user['user_id']);
 
-//ここから始める
-if(purchase_carts($db, $carts) === false){
-  set_error('商品が購入できませんでした。');
+try{
+  $db->beginTransaction();
+
+  purchase_carts($db, $carts);
+  $user_id = $user['user_id'];
+  $purchase_data = new Order($db, $user_id);
+  $purchase_data->insert_order_historys();
+  $order_id = $db->lastInsertId('id');
+
+//オーダーIDを取得
+  foreach($carts as $cart){
+    $item_id = $cart['item_id'];
+    $order_price = $cart['price'];
+    $amount = $cart['amount'];
+    $purchase_data->insert_order_item_historys($order_id,$item_id,$order_price,$amount);
+  }
+  $db->commit();
+}catch(PDOException $e){
+  $db->rollBack();
+  set_error('商品の購入に失敗しました。再度お試しください。');
+  $e->getMessage();
   redirect_to(CART_URL);
-} 
+}
+
 
 $total_price = sum_carts($carts);
 

--- a/www/model/cart.php
+++ b/www/model/cart.php
@@ -175,15 +175,7 @@ function validate_cart_purchase($carts){
   return true;
 }
 
-Class Order{
-
-  private $db;
-  private $user_id;
-  private $order_id;
-  private $item_id;
-  private $order_price;
-  private $amount;
-  
+Class Order{ 
 
   function __construct($db,$user_id)
   {
@@ -191,27 +183,31 @@ Class Order{
     $this->user_id = $user_id;
   }
 
-  public function insert_order_historys(){
+  public function insert_order_historys($carts){
     $sql = "INSERT INTO order_historys(user_id,order_datetime) VALUES(?,?)";
     $datetime = date('YmdHis');
     $params = array(
         array(1,$this->user_id,'int'),
         array(2,$datetime,'str')
     );
-    return execute_query($this->db, $sql, $params);  
+    execute_query($this->db, $sql, $params);
+
+    $order_id = $this->db->lastInsertId('id');
+    foreach ($carts as $cart){
+      $item_id = $cart['item_id'];
+      $order_price = $cart['price'];
+      $amount = $cart['amount'];
+      $this->insert_order_item_historys($order_id,$item_id,$order_price,$amount);
+    }
   }
 
-  public function insert_order_item_historys($order_id,$item_id,$order_price,$amount){
+  private function insert_order_item_historys($order_id,$item_id,$order_price,$amount){
     $sql = "INSERT INTO order_item_historys(order_id,item_id,order_price,amount) VALUES(?,?,?,?)";
-    $this->order_id = $order_id;
-    $this->item_id = $item_id;
-    $this->order_price = $order_price;
-    $this->amount = $amount;
     $params = array(
-      array(1,$this->order_id,'int'),
-      array(2,$this->item_id,'int'),
-      array(3,$this->order_price,'int'),
-      array(4,$this->amount,'int')
+      array(1,$order_id,'int'),
+      array(2,$item_id,'int'),
+      array(3,$order_price,'int'),
+      array(4,$amount,'int')
   );
   return execute_query($this->db, $sql, $params);
   }

--- a/www/model/cart.php
+++ b/www/model/cart.php
@@ -175,3 +175,45 @@ function validate_cart_purchase($carts){
   return true;
 }
 
+Class Order{
+
+  private $db;
+  private $user_id;
+  private $order_id;
+  private $item_id;
+  private $order_price;
+  private $amount;
+  
+
+  function __construct($db,$user_id)
+  {
+    $this->db = $db;
+    $this->user_id = $user_id;
+  }
+
+  public function insert_order_historys(){
+    $sql = "INSERT INTO order_historys(user_id,order_datetime) VALUES(?,?)";
+    $datetime = date('YmdHis');
+    $params = array(
+        array(1,$this->user_id,'int'),
+        array(2,$datetime,'str')
+    );
+    return execute_query($this->db, $sql, $params);  
+  }
+
+  public function insert_order_item_historys($order_id,$item_id,$order_price,$amount){
+    $sql = "INSERT INTO order_item_historys(order_id,item_id,order_price,amount) VALUES(?,?,?,?)";
+    $this->order_id = $order_id;
+    $this->item_id = $item_id;
+    $this->order_price = $order_price;
+    $this->amount = $amount;
+    $params = array(
+      array(1,$this->order_id,'int'),
+      array(2,$this->item_id,'int'),
+      array(3,$this->order_price,'int'),
+      array(4,$this->amount,'int')
+  );
+  return execute_query($this->db, $sql, $params);
+  }
+
+}

--- a/www/model/db.php
+++ b/www/model/db.php
@@ -67,7 +67,7 @@ function execute_query($db, $sql, $params){
       }
     return $statement->execute();
   }catch(PDOException $e){
-    set_error('更新に失敗しました。');
+    set_error('更新に失敗しました。'.$e->getMessage());
   }
   return false;
 }


### PR DESCRIPTION
order_historys及びorder_item_historysへのデータの保存のため、
Class Orderを設定
order_item_historysへの登録は
カート内のデータを個々に登録するためループを用いています。

またデータの削除、履歴の登録をトランザクションしています。